### PR TITLE
Use seperate queues for get/store/has chunk

### DIFF
--- a/dedupqueue.go
+++ b/dedupqueue.go
@@ -57,7 +57,7 @@ func (q *DedupQueue) GetChunk(id ChunkID) (*Chunk, error) {
 }
 
 func (q *DedupQueue) HasChunk(id ChunkID) (bool, error) {
-	req, isInFlight := q.getChunkQueue.loadOrStore(id)
+	req, isInFlight := q.hasChunkQueue.loadOrStore(id)
 
 	if isInFlight { // The request is already in-flight, wait for it to come back
 		data, err := req.wait()
@@ -72,7 +72,7 @@ func (q *DedupQueue) HasChunk(id ChunkID) (bool, error) {
 	req.markDone(hasChunk, err)
 
 	// We're done, drop the request from the queue to avoid keeping all in memory
-	q.getChunkQueue.delete(id)
+	q.hasChunkQueue.delete(id)
 	return hasChunk, err
 }
 


### PR DESCRIPTION
There is a race condition on Windows when using a Cache.

The root cause is that the `Writededupqueue.go` uses the `getChunkQueue` for both `StoreChunk`, `GetChunk` and `HasChunk`

I believe `HasChunk` should instead be using the currently unused `hasChunkQueue`

The race condition:

| Thread 1        | Thread 2           |
| ------------- |:-------------:|
| HasChunk    |  | $1600 |
| Stores request in requests map (Locks getChunkQueue mutex)  | StoreChunk
| | Request is in flight (Mutex is locked so waits) 
| Finds chunk is missing and returns `chunkMissing` on channel |      |
| removes request from request map  (Unlocks mutex)  |
| | Receives a `chunkMissing` error on the channel and returns causing `cache.GetChunk` to return a `chunkMissing` error

An equivalent race condition can happen in the case that `GetChunk` runs before `StoreChunk`, we solve that by separating those requests into separate queues.

However, in the case `GetChunk` occurs whilst a `StoreChunk` happens, we can just wait for `StoreChunk` to return us the chunk, rather than launching a new request  

